### PR TITLE
Rename to @johnhenry/spintax (0.0.0); add CI and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm test
+
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Spintax
 
+> Previously published as `spintax` (last release 1.1.2, now deprecated).
+> Renamed to `@johnhenry/spintax` and restarted at 0.0.0 on import into
+> the @johnhenry family — a new address and era, not a maturity signal.
+
 <img src="https://raw.githubusercontent.com/johnhenry/spintax/main/logo.png" alt="AI.Matey Logo" style="width:256px; height:256px">
 
 A combinatorial string generation library that creates all possible combinations from templates with variable elements.
@@ -7,11 +11,11 @@ A combinatorial string generation library that creates all possible combinations
 ## Installation
 
 ```bash
-npm install spintax
+npm install @johnhenry/spintax
 ```
 
 ```javascript
-import parse from "spintax";
+import parse from "@johnhenry/spintax";
 ```
 
 ### Web Usage
@@ -40,7 +44,7 @@ Spintax is a JavaScript library for generating all possible combinations of temp
 ## Basic Usage
 
 ```javascript
-import parse from "spintax";
+import parse from "@johnhenry/spintax";
 
 // Basic usage with choices
 const variations = parse("Hello, {world|friend|universe}!");
@@ -212,7 +216,7 @@ While `parse` is the primary function exported from the library, there are addit
 ### Supporting Utilities
 
 ```javascript
-import { compile, range, count } from "spintax";
+import { compile, range, count } from "@johnhenry/spintax";
 ```
 
 ### `compile` Tagged Template Function
@@ -276,7 +280,7 @@ If you are migrating from version 0.0.x to 1.0.0, please note that the API has c
 Old:
 
 ```javascript
-import spintax from "spintax";
+import spintax from "@johnhenry/spintax";
 const result = spintax.unspin("{Hello|Hi} John!");
 console.log(result); // "Hello John!" or "Hi John"
 ```
@@ -284,7 +288,7 @@ console.log(result); // "Hello John!" or "Hi John"
 Current:
 
 ```javascript
-import { choose } from "spintax";
+import { choose } from "@johnhenry/spintax";
 const result = choose("{Hello|Hi} John!");
 console.log(result()); // "Hello John!" or "Hi John"
 ```
@@ -296,7 +300,7 @@ console.log(result()); // "Hello John!" or "Hi John"
 Old:
 
 ```javascript
-import spintax from "spintax";
+import spintax from "@johnhenry/spintax";
 const count = spintax.countVariations("{Hello|Hi} John!");
 console.log(count); // 2
 ```
@@ -304,7 +308,7 @@ console.log(count); // 2
 Current:
 
 ```javascript
-import { count } from "spintax";
+import { count } from "@johnhenry/spintax";
 const count = count("{Hello|Hi} John!");
 console.log(count); // 2
 ```

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "spintax",
-  "version": "1.1.2",
+  "name": "@johnhenry/spintax",
+  "version": "0.0.0",
   "description": "Combinatorial string generator using spintax syntax",
   "type": "module",
   "main": "src/index.mjs",
   "types": "types.d.ts",
-  "homepage": "https://github.com/johnhenry/spintax",
+  "homepage": "https://opensource.johnhenry.me/spintax/",
   "scripts": {
     "test": "node --test test/**/*.test.mjs",
     "demo": "node examples/demo.mjs"
@@ -36,6 +36,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/johnhenry/spintax.git"
+    "url": "git+https://github.com/johnhenry/spintax.git"
   }
 }


### PR DESCRIPTION
Part of the @johnhenry family adoption. Scoped name, version restarts at 0.0.0. This repo had zero CI/publish automation — added a Node 20/22/24 test matrix and a release-triggered publish workflow, matching the family standard. 34/34 tests pass.