### PR TITLE
docs: examples overhaul, changelog, README fixes, CI smoke step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,3 +17,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm test
+      - name: Examples smoke test
+        run: npm run examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Numbered runnable examples (`examples/01`–`05`) covering generation,
+  ranges and steps, back references, `count`/`choose` without expansion,
+  and `compile` template reuse, with an index in `examples/README.md`
+- `npm run examples` script that runs every numbered example, wired into CI
+  as a smoke step
+- This changelog
+- Documentation section at
+  [opensource.johnhenry.me/spintax](https://opensource.johnhenry.me/spintax/)
+
+### Fixed
+
+- README: CDN import URLs now point at the scoped `@johnhenry/spintax`
+  package instead of the deprecated unscoped `spintax@1.1.2`
+- README: the configuration-generation example now uses custom delimiters
+  (`patternStart`/`patternEnd`) — with the default braces, JSON-shaped
+  templates are mangled because `{`/`}` are structural and have no escape
+
+## [0.0.0] - 2026-08-25
+
+### Changed
+
+- Renamed from `spintax` to `@johnhenry/spintax` and restarted the version
+  line at 0.0.0 on import into the @johnhenry family — a new address and
+  era, not a maturity signal. The last unscoped release was `spintax@1.1.2`
+  (now deprecated); the API is unchanged from that release.
+- Added CI (test matrix on Node 20/22/24) and a release-triggered npm
+  publish workflow with provenance

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 > Renamed to `@johnhenry/spintax` and restarted at 0.0.0 on import into
 > the @johnhenry family — a new address and era, not a maturity signal.
 
-<img src="https://raw.githubusercontent.com/johnhenry/spintax/main/logo.png" alt="AI.Matey Logo" style="width:256px; height:256px">
+<img src="https://raw.githubusercontent.com/johnhenry/spintax/main/logo.png" alt="Spintax Logo" style="width:256px; height:256px">
 
 A combinatorial string generation library that creates all possible combinations from templates with variable elements.
+
+Full documentation: [opensource.johnhenry.me/spintax](https://opensource.johnhenry.me/spintax/)
 
 ## Installation
 
@@ -24,11 +26,11 @@ You can also import the library directly in your HTML file using a CDN:
 
 ```html
 <script type="module">
-  import parse from "https://cdn.jsdelivr.net/npm/spintax@1.1.2/src/index.mjs";
+  import parse from "https://cdn.jsdelivr.net/npm/@johnhenry/spintax/src/index.mjs";
 </script>
 ```
 
-Note that `https://ga.jspm.io/npm:spintax@1.1.2/src/index.mjs` is also available.
+Note that `https://ga.jspm.io/npm:@johnhenry/spintax@0.0.0/src/index.mjs` is also available.
 
 ## Key Features
 
@@ -68,7 +70,7 @@ const products = parse("{Product|Service} #{1,3} ({Standard|Premium})");
 
 // Back references
 const associations = parse(
-  "The {blue|straw|rasp}berries taste like {$0}berries)"
+  "The {blue|straw|rasp}berries taste like {$0}berries"
 );
 // Generates all combinations with back references: "The blueberries taste like blueberries", "The strawberries taste like strawberries", "The raspberries taste like raspberries", etc.
 ```
@@ -140,9 +142,14 @@ parse("/api/v{1,3}/{users|items}/{1,100,10}");
 
 ### Configuration Generation
 
+Braces are structural everywhere and have no escape syntax, so JSON-shaped
+templates need custom delimiters (otherwise the JSON's own `{`/`}` are
+consumed as pattern markers):
+
 ```javascript
 parse(
-  '{"timeout": {1000,5000,1000}, "retries": {1,3}, "mode": "{strict|lenient}"}'
+  '{"timeout": <1000,5000,1000>, "retries": <1,3>, "mode": "<strict|lenient>"}',
+  { patternStart: "<", patternEnd: ">" }
 );
 // Generates valid JSON strings with all combinations of parameters
 ```
@@ -260,6 +267,17 @@ Omitting the index returns a random combination:
 ```javascript
 gen(); // "Hello world!" or "Hello nurse!"
 ```
+
+## Examples
+
+Runnable, commented examples live in [`examples/`](./examples/README.md) —
+run them all with `npm run examples`:
+
+1. [Generate every variation](./examples/01-generate-every-variation.mjs) — basic parsing, cross products, iteration order
+2. [Step through number ranges](./examples/02-step-through-number-ranges.mjs) — steps, decimals, the always-included end value
+3. [Echo choices with back references](./examples/03-echo-choices-with-backrefs.mjs) — `{$n}` semantics and edge cases
+4. [Count and pick without expanding](./examples/04-count-and-pick-without-expanding.mjs) — `count`/`choose` on huge spaces
+5. [Reuse compiled templates](./examples/05-reuse-compiled-templates.mjs) — `compile`, re-iteration, chunked draining
 
 ## Browser Compatibility
 

--- a/examples/01-generate-every-variation.mjs
+++ b/examples/01-generate-every-variation.mjs
@@ -1,0 +1,34 @@
+/**
+ * Generate every variation of a template.
+ *
+ * `parse` (the default export) turns a template with {...} patterns into a
+ * lazy iterable of every combination. Nothing is generated until you
+ * iterate, and iteration order is guaranteed: the rightmost pattern varies
+ * fastest (odometer order).
+ *
+ * Run with: node examples/01-generate-every-variation.mjs
+ */
+
+import parse from "../src/index.mjs";
+
+// A single choices pattern — one output per option
+console.log("-- Choices --");
+for (const s of parse("Hello, {world|friend|universe}!")) {
+  console.log(s);
+}
+// Hello, world!
+// Hello, friend!
+// Hello, universe!
+
+// Multiple patterns multiply: 2 sizes x 2 shapes x 2 colors = 8 strings,
+// with the rightmost pattern cycling first.
+console.log("\n-- Cross product (rightmost varies fastest) --");
+for (const s of parse("{small|large} {box|circle} in {red|blue}")) {
+  console.log(s);
+}
+
+// Whitespace rule: choices keep whitespace as part of the option.
+// "{A |B}" yields "A " (trailing space) — don't pad choice lists.
+console.log("\n-- Whitespace is part of a choice --");
+console.log(JSON.stringify([...parse("x{A |B}y")]));
+// ["xA y","xBy"]

--- a/examples/02-step-through-number-ranges.mjs
+++ b/examples/02-step-through-number-ranges.mjs
@@ -1,0 +1,37 @@
+/**
+ * Step through number ranges.
+ *
+ * {start,end} and {start,end,step} expand to inclusive numeric ranges.
+ * Whitespace inside a range body is ignored, decimals and negatives work,
+ * and the end value is ALWAYS included — even when the step overshoots it.
+ *
+ * Run with: node examples/02-step-through-number-ranges.mjs
+ */
+
+import parse, { range, compile } from "../src/index.mjs";
+
+console.log("-- Basic range --");
+console.log([...parse("Count: {1,5}")].join(", "));
+// Count: 1 ... Count: 5
+
+console.log("\n-- With a step --");
+console.log([...parse("Even: {0,10,2}")].join(", "));
+// 0, 2, 4, 6, 8, 10
+
+console.log("\n-- The end value is always included, even off-step --");
+console.log([...parse("Day {7,30,7}")].join(", "));
+// Day 7, Day 14, Day 21, Day 28, Day 30  <- 30 appended despite step 7
+
+console.log("\n-- Decimals and negatives --");
+console.log([...parse("{0.5,1.5,0.5}")].join(", ")); // 0.5, 1, 1.5
+console.log([...parse("{-2,2}")].join(", "));        // -2 .. 2
+
+console.log("\n-- Caution: a descending range is empty --");
+// Ranges only count up. One empty pattern zeroes the whole template.
+console.log(JSON.stringify([...parse("n {5,1}")])); // []
+
+// Need a strict step grid with no appended end? Use range() with
+// includeEnd = false through the compile tagged template.
+console.log("\n-- Strict grid via range(start, end, step, false) --");
+console.log([...compile`Day ${range(7, 30, 7, false)}`].join(", "));
+// Day 7, Day 14, Day 21, Day 28

--- a/examples/03-echo-choices-with-backrefs.mjs
+++ b/examples/03-echo-choices-with-backrefs.mjs
@@ -1,0 +1,41 @@
+/**
+ * Echo earlier choices with back references.
+ *
+ * {$n} repeats the value chosen by the n-th real pattern (0-based, counting
+ * only non-back-reference patterns, left to right). Back references do NOT
+ * multiply the combination count — they echo choices already made.
+ *
+ * Run with: node examples/03-echo-choices-with-backrefs.mjs
+ */
+
+import parse, { count } from "../src/index.mjs";
+
+console.log("-- Basic back reference --");
+for (const s of parse("The {blue|straw|rasp}berries taste like {$0}berries")) {
+  console.log(s);
+}
+// 3 results, not 9 — {$0} echoes the first pattern's value
+
+console.log("\n-- count() ignores back references --");
+console.log(count("The {a|b}berries taste like {$0}berries")); // 2, not 4
+
+console.log("\n-- Works with ranges too --");
+for (const s of parse("Number {1,3} doubled is {$0} * 2")) {
+  console.log(s);
+}
+
+console.log("\n-- Multiple patterns: indices skip the back references --");
+for (const s of parse("The {red|blue} {box|circle} is a {$0} {$1}.")) {
+  console.log(s);
+}
+
+console.log("\n-- Edge cases --");
+// Invalid index -> left literally in the output
+console.log([...parse("Pick {a|b}, not {$5}")][0]); // "Pick a, not {$5}"
+// $ outside a standalone {$n} body is plain text
+console.log([...parse("Price: ${10|20}, ref {$0}")][0]); // "Price: $10, ref 10"
+
+console.log("\n-- Custom marker --");
+for (const s of parse("{red|blue} is {@0}", { backReferenceMarker: "@" })) {
+  console.log(s);
+}

--- a/examples/04-count-and-pick-without-expanding.mjs
+++ b/examples/04-count-and-pick-without-expanding.mjs
@@ -1,0 +1,37 @@
+/**
+ * Count and pick without expanding the full combination space.
+ *
+ * Patterns multiply: ten four-option choices is 4^10 = 1,048,576 strings.
+ * count() computes that product from pattern sizes alone, and choose()
+ * builds specific (or random) combinations directly — neither expands the
+ * cross product, so both stay fast no matter how large the space is.
+ *
+ * Run with: node examples/04-count-and-pick-without-expanding.mjs
+ */
+
+import { count, choose } from "../src/index.mjs";
+
+// count() is the safe pre-flight check before [...parse(t)]
+console.log("-- How big is this template? --");
+console.log(count("/api/v{1,3}/{users|items}/{1,100}")); // 600
+console.log(count("{a|b|c|d} ".repeat(10))); // 1048576 — instant
+
+// choose() returns a picker: positional 0-based indices, one per pattern,
+// in left-to-right order. Iteration order guarantees make these stable.
+console.log("\n-- Deterministic picks --");
+const pick = choose("Count: {1,5} {A|B|C}");
+console.log(pick(0, 0)); // "Count: 1 A"
+console.log(pick(1, 2)); // "Count: 2 C"
+console.log(pick(4, 1)); // "Count: 5 B"
+
+// Omit indices (or pass undefined) for random slots
+console.log("\n-- Random sampling from a huge space --");
+const sample = choose("{tiny|small|large|huge} {red|green|blue} #{1,1000}");
+console.log("space size:", count("{tiny|small|large|huge} {red|green|blue} #{1,1000}"));
+for (let i = 0; i < 3; i++) {
+  console.log(sample());
+}
+
+// Caution: indices are not validated — out-of-range gives "undefined"
+console.log("\n-- Out-of-range index --");
+console.log(choose("Hi {a|b}")(5)); // "Hi undefined"

--- a/examples/05-reuse-compiled-templates.mjs
+++ b/examples/05-reuse-compiled-templates.mjs
@@ -1,0 +1,50 @@
+/**
+ * Reuse compiled templates and stream large spaces lazily.
+ *
+ * compile is a tagged template that embeds real JavaScript values —
+ * arrays of choices, range() generators, plain expressions — instead of
+ * string patterns, so there is no delimiter parsing (and no escaping
+ * worries). Both compile`...` and parse(...) return RE-ITERABLE objects:
+ * build once, walk as many times as you like, each walk lazy from the top.
+ *
+ * Run with: node examples/05-reuse-compiled-templates.mjs
+ */
+
+import parse, { compile, range } from "../src/index.mjs";
+
+// Build once...
+const endpoints = compile`/api/${["v1", "v2"]}/${["users", "items"]}/${range(1, 3)}`;
+
+// ...iterate many times. Each for...of restarts the generator.
+console.log("-- First pass: preview --");
+let preview = 0;
+for (const url of endpoints) {
+  console.log(url);
+  if (++preview === 3) break; // lazy — the remaining 9 are never built
+}
+
+console.log("\n-- Second pass: full walk of the same object --");
+console.log([...endpoints].length, "endpoints"); // 12
+
+// Static expressions interpolate as-is; arrays/range() become dimensions.
+const host = "example.com";
+const pages = compile`https://${host}/${["docs", "blog"]}?page=${range(1, 2)}`;
+console.log("\n-- Mixing static values and dimensions --");
+console.log([...pages].join("\n"));
+
+// Chunked processing pattern for very large spaces: hold the iterator,
+// drain N at a time, resume later without recomputing anything.
+console.log("\n-- Chunked draining of a large space --");
+const big = parse("{a|b|c|d|e}{a|b|c|d|e}{a|b|c|d|e}{1,100}"); // 12,500
+const iterator = big[Symbol.iterator]();
+const chunk = (n) => {
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const { value, done } = iterator.next();
+    if (done) break;
+    out.push(value);
+  }
+  return out;
+};
+console.log("chunk 1:", chunk(3).join(", "));
+console.log("chunk 2:", chunk(3).join(", ")); // resumes where chunk 1 left off

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Examples
+
+Run any example directly (`node examples/01-generate-every-variation.mjs`)
+or run them all with `npm run examples` from the repo root.
+
+| Example | Shows |
+| --- | --- |
+| [01-generate-every-variation.mjs](./01-generate-every-variation.mjs) | Basic `parse` usage, cross products, guaranteed rightmost-first iteration order, whitespace-in-choices gotcha |
+| [02-step-through-number-ranges.mjs](./02-step-through-number-ranges.mjs) | Ranges with steps, decimals, negatives, the always-included end value, the empty descending-range trap |
+| [03-echo-choices-with-backrefs.mjs](./03-echo-choices-with-backrefs.mjs) | `{$n}` back references, why they don't multiply `count()`, invalid-reference behavior, custom markers |
+| [04-count-and-pick-without-expanding.mjs](./04-count-and-pick-without-expanding.mjs) | `count` and `choose` on huge combination spaces without materializing them |
+| [05-reuse-compiled-templates.mjs](./05-reuse-compiled-templates.mjs) | The `compile` tagged template, re-iterable template objects, lazy chunked draining |
+| [demo.mjs](./demo.mjs) | Kitchen-sink tour of the whole API (`npm run demo`) |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://opensource.johnhenry.me/spintax/",
   "scripts": {
     "test": "node --test",
-    "demo": "node examples/demo.mjs"
+    "demo": "node examples/demo.mjs",
+    "examples": "for f in examples/0*.mjs; do echo \"== $f ==\" && node \"$f\" || exit 1; done"
   },
   "keywords": [
     "spintax",


### PR DESCRIPTION
Part of the coordinated docs overhaul across the @johnhenry family.

## What's here

- **Five numbered runnable examples** in `examples/` with behavioral names, plus an index in `examples/README.md`:
  1. `01-generate-every-variation` — basic parsing, cross products, guaranteed rightmost-first iteration order
  2. `02-step-through-number-ranges` — steps, decimals, negatives, the always-included end value, the empty descending-range trap
  3. `03-echo-choices-with-backrefs` — `{$n}` semantics, why back references don't multiply `count()`, custom markers
  4. `04-count-and-pick-without-expanding` — `count`/`choose` on 10^6-string spaces without materializing them
  5. `05-reuse-compiled-templates` — `compile` tagged template, re-iterable templates, chunked draining
- **`npm run examples`** loop script, wired into the test workflow as a smoke step
- **`CHANGELOG.md`** with an Unreleased section and a dated 0.0.0 provenance entry (renamed from unscoped `spintax`, last unscoped release 1.1.2)
- **README fixes:**
  - CDN import URLs now point at scoped `@johnhenry/spintax` instead of deprecated `spintax@1.1.2`
  - The configuration-generation example was actually broken as written — default `{`/`}` delimiters mangle JSON-shaped templates (verified: the outer brace is consumed as a pattern marker). Rewritten with `patternStart`/`patternEnd` custom delimiters and verified to emit 30 valid JSON strings
  - Link to the new docs section at https://opensource.johnhenry.me/spintax/, fixed logo alt text and a stray paren in the back-reference example

## Gate

- `npm test`: 34/34 pass (6 suites)
- `npm run examples`: all five examples run clean
- No changes to `src/` or the test script (left as bare `node --test`)